### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README
+++ b/README
@@ -5,7 +5,7 @@ django-kungfu
 mechanism so it's fairly easy to integrate development or deployment-related 
 settings overrides.
 
-The idea came after I used for a while the beatiful configuration system 
+The idea came after I used for a while the beautiful configuration system 
 implemented in `Flask
 <http://flask.pocoo.org/>`_. In fact, the majority of the code was inspired
 by the Flask implementation located `here


### PR DESCRIPTION
@delinhabit, I've corrected a typographical error in the documentation of the [django-kungfu](https://github.com/delinhabit/django-kungfu) project. Specifically, I've changed beatiful to beautiful. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
